### PR TITLE
Updates podspec to handle Assets.xcassets

### DIFF
--- a/DispatchSDK.podspec
+++ b/DispatchSDK.podspec
@@ -20,5 +20,8 @@ Pod::Spec.new do |s|
   s.resource_bundles = {
     'DispatchSDK' => ['Sources/DispatchSDK/Resources/**/*']
   }
+  
+  s.resources = ['Sources/DispatchSDK/Resources/*.{xcassets}']
+
 end
 

--- a/DispatchSDK.podspec
+++ b/DispatchSDK.podspec
@@ -1,11 +1,3 @@
-#
-# Be sure to run `pod lib lint DispatchSDK.podspec' to ensure this is a
-# valid spec before submitting.
-#
-# Any lines starting with a # are optional, but their use is encouraged
-# To learn more about a Podspec see https://guides.cocoapods.org/syntax/podspec.html
-#
-
 Pod::Spec.new do |s|
   s.name             = 'DispatchSDK'
   s.version          = '1.0.0'
@@ -13,19 +5,20 @@ Pod::Spec.new do |s|
 
   s.description      = <<-DESC
   iOS SDK that allows applications to enable enable Dispatch’s checkout conversion experiences to be invoked in-app
-    DESC
+  DESC
 
   s.homepage         = 'https://github.com/iex-xyz/dispatch-ios-sdk'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Dispatch Solutions, Inc' => 'stephensilber@gmail.com' }
   s.source           = { :git => 'https://github.com/iex-xyz/dispatch-ios-sdk.git', :tag => s.version.to_s }
 
-  s.ios.deployment_target = '15.0'
+  s.ios.deployment_target = '12.0'
   s.swift_version    = '5.5'
 
   s.source_files = 'Sources/DispatchSDK/Sources/**/*'
   
   s.resource_bundles = {
-    'DispatchSDK' => ['Sources/DispatchSDK/Resources/*.json']
+    'DispatchSDK' => ['Sources/DispatchSDK/Resources/**/*']
   }
 end
+

--- a/Sources/DispatchSDK/Sources/Utils/Icons.swift
+++ b/Sources/DispatchSDK/Sources/Utils/Icons.swift
@@ -57,4 +57,14 @@ struct Icons {
         static var googlePayBadgeDark = Image("payment-badge-gpay-dark", bundle: .module)
 
     }
+    
+    static func bundledImage(named: String) -> UIImage? {
+        let image = UIImage(named: named)
+        if image == nil {
+            return UIImage(named: named, in: Bundle(for: BundleFinder.self), compatibleWith: nil)
+        } // Replace MyBasePodClass with yours
+        return image
+    }
 }
+
+fileprivate class BundleFinder {}

--- a/Sources/DispatchSDK/Sources/Utils/Icons.swift
+++ b/Sources/DispatchSDK/Sources/Utils/Icons.swift
@@ -57,14 +57,4 @@ struct Icons {
         static var googlePayBadgeDark = Image("payment-badge-gpay-dark", bundle: .module)
 
     }
-    
-    static func bundledImage(named: String) -> UIImage? {
-        let image = UIImage(named: named)
-        if image == nil {
-            return UIImage(named: named, in: Bundle(for: BundleFinder.self), compatibleWith: nil)
-        } // Replace MyBasePodClass with yours
-        return image
-    }
 }
-
-fileprivate class BundleFinder {}


### PR DESCRIPTION
We're missing image assets when installed via Cocoapods. This should fix it by including the .xcassets resources bundle in the podspec