### PR TITLE
Scale Checkout Success View Base Image to Fit

### DIFF
--- a/Sources/DispatchSDK/Sources/UI/CheckoutSuccessView.swift
+++ b/Sources/DispatchSDK/Sources/UI/CheckoutSuccessView.swift
@@ -17,7 +17,7 @@ struct CheckoutSuccessView: View {
                     AsyncImage(url: url, content: { content in
                         content
                             .resizable()
-                            .scaledToFill()
+                            .scaledToFit()
                     }, placeholder: {
                         ProgressView()
                             .foregroundStyle(.primary)

--- a/Sources/DispatchSDK/Sources/UI/CheckoutSuccessView.swift
+++ b/Sources/DispatchSDK/Sources/UI/CheckoutSuccessView.swift
@@ -14,17 +14,19 @@ struct CheckoutSuccessView: View {
         ZStack {
             VStack {
                 if let imageUrlString = viewModel.checkout.product.baseImages.first, let url = URL(string: imageUrlString) {
-                    AsyncImage(url: url, content: { content in
-                        content
-                            .resizable()
-                            .scaledToFit()
-                    }, placeholder: {
-                        ProgressView()
-                            .foregroundStyle(.primary)
-                    })
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 320)
-                    .clipShape(Rectangle())
+                    GeometryReader { geometry in
+                        AsyncImage(url: url, content: { content in
+                            content
+                                .resizable()
+                                .scaledToFill()
+                        }, placeholder: {
+                            ProgressView()
+                                .foregroundStyle(.primary)
+                        })
+                        .frame(width: geometry.size.width)
+                        .frame(height: 320)
+                        .clipShape(Rectangle())
+                    }
                 }
                 
                 ScrollView {


### PR DESCRIPTION
## Bug
![Simulator Screenshot - iPhone 15 Pro - 2024-05-30 at 13 47 55](https://github.com/iex-xyz/dispatch-ios-sdk/assets/168591487/6813babc-f378-4bdf-930d-34ce5030558b)

This was happening because the image was scaled to fill, so the whole view became distorted.

## Fix
<img width="203" alt="Screenshot 2024-05-30 at 3 11 15 PM" src="https://github.com/iex-xyz/dispatch-ios-sdk/assets/168591487/a7f8e39f-18ce-43dc-b047-7e02eaf262f8">

By scaling the image to fit, the view retains the appropriate zoom