### PR TITLE
Forwards distributionId changes to NetworkService for updated request headers

### DIFF
--- a/Sources/DispatchSDK/Sources/DispatchSDK.swift
+++ b/Sources/DispatchSDK/Sources/DispatchSDK.swift
@@ -164,6 +164,7 @@ class DefaultDispatchSDK: DispatchSDKService {
     
     func updateDistributionId(_ distributionId: String) {
         self.distributionId = distributionId
+        self.apiClient.updateDistributionId(distributionId)
         self.analyticsClient.updateDistributionId(distributionId)
     }
 

--- a/Sources/DispatchSDK/Sources/GraphQL/GraphQLClient.swift
+++ b/Sources/DispatchSDK/Sources/GraphQL/GraphQLClient.swift
@@ -29,4 +29,8 @@ class GraphQLClient {
     func updateEnvironment(_ environment: AppEnvironment) {
         self.environment = environment
     }
+
+    func updateDistributionId(_ distributionId: String) {
+        self.networkService.updateDistribution(distributionId)
+    }
 }

--- a/Sources/DispatchSDK/Sources/GraphQL/NetworkService.swift
+++ b/Sources/DispatchSDK/Sources/GraphQL/NetworkService.swift
@@ -8,16 +8,21 @@ enum NetworkError: Error {
 @available(iOS 15.0, *)
 protocol NetworkService {
     func performRequest(_ urlRequest: URLRequest) async throws -> Data
+    func updateDistribution(_ distributionId: String)
 }
 
 @available(iOS 15.0, *)
 class RealNetworkService: NetworkService {
     
     private let applicationId: String
-    private let distributionId: String
+    private var distributionId: String
 
     init(applicationId: String, distributionId: String) {
         self.applicationId = applicationId
+        self.distributionId = distributionId
+    }
+
+    func updateDistribution(_ distributionId: String) {
         self.distributionId = distributionId
     }
     

--- a/Sources/DispatchSDK/Sources/GraphQL/NetworkService.swift
+++ b/Sources/DispatchSDK/Sources/GraphQL/NetworkService.swift
@@ -49,6 +49,10 @@ class RealNetworkService: NetworkService {
 // TODO: Add mock data support
 @available(iOS 15.0, *)
 class PreviewNetworkService: NetworkService {
+    func updateDistribution(_ distributionId: String) {
+        //
+    }
+    
     func performRequest(_ urlRequest: URLRequest) async throws -> Data {
         throw NetworkError.serverError(statusCode: 400)
     }
@@ -56,6 +60,10 @@ class PreviewNetworkService: NetworkService {
 
 @available(iOS 13.0.0, *)
 class EmptyNetworkService: NetworkService {
+    func updateDistribution(_ distributionId: String) {
+        //
+    }
+    
     @available(iOS 13.0.0, *)
     func performRequest(_ urlRequest: URLRequest) async throws -> Data {
         throw NetworkError.serverError(statusCode: 400)


### PR DESCRIPTION
This change ensures any `distributionId` updates get passed and stored in the `NetworkService` which constructs request headers and is responsible for setting `x-source-id`